### PR TITLE
Fix broken internal link to Notebook Submissions page (#9)

### DIFF
--- a/pages/notebook-submissions.md
+++ b/pages/notebook-submissions.md
@@ -1,4 +1,8 @@
-# Computational Notebook Submission Formats
+---
+layout: page
+title: Computational Notebook Submission Formats
+permalink: /submissions/notebooks/
+---
 
 Below, we outline the categories that we will accept for computational notebook submissions.
 We have included an innovative uses category, to be inclusive of as many creative uses of notebooks as possible, however, this year will only accept [Jupyter Notebooks](https://jupyter.org/), [R Markdown](https://rmarkdown.rstudio.com/) documents (including [Shiny](https://shiny.rstudio.com/) apps), and [Quarto Markdown](https://quarto.org/docs/authoring/markdown-basics.html) documents.

--- a/pages/participate.md
+++ b/pages/participate.md
@@ -65,7 +65,7 @@ Given the necessity for software in all aspects of research today, we would
 also like to encourage the submission of computational notebooks. To account
 for the broad variety of use cases for notebooks, we are accepting submissions
 in three categories, described in detail on the
-[Notebook Submissions page](https://us-rse.org/usrse23/notebook-submissions).
+[Notebook Submissions page]({{ '/submissions/notebooks/' | relative_url }}).
 Accepted notebooks will be given the opportunity for a 15 minute oral
 presentation and included in our digital proceedings. There will be a US-RSE
 community call in March dedicated to discussing details and answering questions


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the Committee chairs are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for the Committee chairs
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add front matter to notebook-submissions.md with permalink
- Use that permalink to specify link URL through `relative_url`

## Motivation and Context

- Resolves #9
- Current implementation for the fix from https://stackoverflow.com/a/47098718

## Does it work?

- I've built the site locally using Docker and the link seems to work now (see screenshots)
- I believe the fix should be valid for the published website as well thanks to the `relative_url` function

![image](https://user-images.githubusercontent.com/48035537/219068117-bad96bf5-d934-484d-827d-1994dc41dcb5.png)

![image](https://user-images.githubusercontent.com/48035537/219068240-a7e30bee-5593-4d0d-aaa8-aa6e4252c00b.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary (N/A)

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jscubida

