### PR TITLE
Add social button for Matrix

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,0 +1,45 @@
+name: Check Spelling and URLs
+
+on: [pull_request]
+
+# Kill concurrent jobs from the same PR/branch - only one will run at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  urlcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check Spelling
+      uses: crate-ci/typos@12c64918956d94e55a2ca8c5cbca111e759f5654 # version 1.13.8
+      with:
+        files: ./_posts ./pages ./README.md ./index.html
+
+    - name: URLs-checker
+
+      uses: urlstechie/urlchecker-action@0.0.34
+      with:
+        # A comma-separated list of file types to cover in the URL checks
+        file_types: .md,.py,.yml
+
+        # Choose whether to include file with no URLs in the prints.
+        print_all: false
+
+        # More verbose summary at the end of a run
+        verbose: true
+
+        # How many times to retry a failed request (defaults to 1)
+        retry_count: 3
+
+        # Google Forms is having enormous timeouts
+        timeout: 10
+
+        # Exclude these patterns from the checker
+        exclude_patterns: supercomputing.org
+
+        # Exclude these files from the checker
+        exclude_files: README.md,SocialNetworks.yml,_config.yml,tests/test_,.github/workflows

--- a/_config.yml
+++ b/_config.yml
@@ -92,6 +92,7 @@ social-network-links:
 #  facebook:
   github: USRSE
   twitter: us_rse
+  matrix: '#us-rse-con-2023:matrix.org'
 #  reddit:
 #  google-plus:
 #  linkedin:

--- a/_data/SocialNetworks.yml
+++ b/_data/SocialNetworks.yml
@@ -95,3 +95,8 @@ yelp:
   name: "Yelp"
   baseURL: "https://{{ site.author.yelp }}.yelp.com"
   icon: "fa-yelp"
+
+matrix:
+  name: "Matrix"
+  baseURL: "https://app.element.io/#/room/"
+  icon: "fa-comments"


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the Committee chairs are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for the Committee chairs
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->
This update adds a social button to the footer linking to the Matrtix room `#us-rse-con-2023:matrix.org` (one of two existing rooms in the `#us-rse:matrix.org` Matrix Space), using for the sake of simplicity a direct link to the Matrix.org hosted Element client web app, allowing people without a Matrix account to view the public room. 

## Motivation and Context
The RSE community is more likely than most to have encountered and have experience using Matrix, given its growing popularity among for example open source projects who have transitioned from IRC to this decentralized, open protocol. Honetly I think it will add some "street cred" to the RSE conference website :-)  

On a practical level it provides another way for people to receive "push notifications" of announcements if they choose, by joining the room and setting their notification level appropriately. (We could use one of Matrix's many bridges to potentially automate mirroring announcements from [the US-RSE Slack channel](https://matrix.org/bridges/#slack) or from [the announcement email list](https://matrix.org/bridges/#email), but that discussion is outside the scope of this PR.)

See https://matrix.org/faq/#what-is-matrix and https://decentci.ncsa.illinois.edu/what-is-matrix/ to learn more about what Matrix is.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [x] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jscubida

