### PR TITLE
Extend due date for Workshops/BoFs/Tutorials to April 4

### DIFF
--- a/_posts/2023-03-15-extend-due-date.md
+++ b/_posts/2023-03-15-extend-due-date.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: EXTENDED: Submission Deadline for Workshops/BoFs/Tutorials
+date: 2023-03-15
+tags:
+---
+
+The due date for Workshops, Birds of a Feather (BoFs), and Tutorial submissions
+has been extended to **April 4, 2023**.

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ fb-img:
   <h3> Important Dates </h3>
   <ul>
   <li><b>Submissions open</b>: Tuesday, February 14, 2023</li>
-  <li><b>Workshops, Tutorials, and BoF submissions due</b>: Monday, March 20, 2023</li>
+  <li><b>Workshops, Tutorials, and BoF submissions due</b>: Tuesday, April 4, 2023 - <b>EXTENDED</b></li>
   <li><b>Papers / Notebooks due</b>: Monday, May 1, 2023</li>
   <li><b>Poster / Talk abstracts due</b>: Monday, June 19, 2023</li>
   <li><b>Conference Date</b>: October 16-18, 2023, Chicago, IL</li>

--- a/pages/dates.md
+++ b/pages/dates.md
@@ -9,7 +9,7 @@ permalink: /dates/
 ## Submissions
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Monday, March 20, 2023
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 4, 2023 - **EXTENDED**
 - **Notification of authors for workshops, tutorials, and BoFs**: Monday, April 24, 2023
 - **Papers / Notebooks due**: Monday, May 1, 2023
 - **Registration opens**: Monday, May 1, 2023

--- a/pages/participate.md
+++ b/pages/participate.md
@@ -27,7 +27,7 @@ include (but are not limited to):
 **Important Dates**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Monday, March 20, 2023
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 4, 2023 - **EXTENDED**
 - **Papers / Notebooks due**: Monday, May 1, 2023
 - **Poster / Talk abstracts due**: Monday, June 19, 2023
 

--- a/pages/participate.md
+++ b/pages/participate.md
@@ -119,7 +119,7 @@ estimated number of attendees, and level of participation expected.
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Monday, March 20, 2023
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 4, 2023 - **EXTENDED**
 - **Notification of authors for workshops, tutorials, and BoFs**: Monday, April 24, 2023
 - **Registration for authors of workshops, tutorials, and BoFs**: Monday, June 26, 2023
 
@@ -136,7 +136,7 @@ and specify the level of participation expected.
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Monday, March 20, 2023
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 4, 2023 - **EXTENDED**
 - **Notification of authors for workshops, tutorials, and BoFs**: Monday, April 24, 2023
 - **Registration for authors of workshops, tutorials, and BoFs**: Monday, June 26, 2023
 


### PR DESCRIPTION
## Description
We have chosen to extend the due date to April 4.

## Motivation and Context
We would like to give people more time.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jscubida

