### PR TITLE
Fix malformed URLs in RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -6,8 +6,8 @@ layout: null
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
+    <link>{{ site.url }}/usrse23</link>
+    <atom:link href="{{ site.url }}/usrse23/feed.xml" rel="self" type="application/rss+xml" />
     {% for post in site.posts limit:20 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
@@ -16,8 +16,8 @@ layout: null
           {{ post.content | strip_html | xml_escape | truncatewords: 50 }}
         </description>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-        <link>{{ site.url }}{{ post.url }}</link>
-        <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+        <link>{{ site.url }}/usrse23{{ post.url }}</link>
+        <guid isPermaLink="true">{{ site.url }}/usrse23{{ post.url }}</guid>
       </item>
     {% endfor %}
   </channel>


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the Committee chairs are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for the Committee chairs
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The links generated by the RSS feed for the conference site are broken because they lack the base path `/usrse23`.

## Motivation and Context
The RSS feed of the site posts is broken because the links are malformed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [x] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jscubida

