### PR TITLE
Change limit for short papers

### DIFF
--- a/pages/participate/participate.md
+++ b/pages/participate/participate.md
@@ -56,8 +56,11 @@ long papers will be 15 minutes). Both types of submissions will be included
 in the digital proceedings. 
 
 Papers should follow the [IEEE format](https://www.ieee.org/conferences/publishing/templates.html).
-Short papers should have not more than 500 words and long papers should be no-longer
-than 8 pages in length. We particularly encourage submissions from first-time conference
+Short papers should have no fewer than 300 words, but no more than two pages;
+long papers should be no longer than 8 pages in length. Neither limit
+includes references.
+
+We particularly encourage submissions from first-time conference
 presenters and from members of groups that have historically been underrepresented in
 the scientific community.
 


### PR DESCRIPTION
## Description
The limit for short papers was even shorter than the limit for talks. This gives a bit more wiggle room.

## Motivation and Context
We want the space limits to make sense.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

