### PR TITLE
Extend due date for WS/BoF/Tutorials to April 11

### DIFF
--- a/_posts/2023-04-03-extend-due-date.md
+++ b/_posts/2023-04-03-extend-due-date.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "SECOND EXTENSION: Submission Deadline for Workshops/BoFs/Tutorials"
+date: 2023-03-15
+tags:
+---
+
+The due date for Workshops, Birds of a Feather (BoFs), and Tutorial submissions
+has been extended to **April 11, 2023, Anywhere on Earth (AoE)**.

--- a/_posts/2023-04-03-extend-due-date.md
+++ b/_posts/2023-04-03-extend-due-date.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "SECOND EXTENSION: Submission Deadline for Workshops/BoFs/Tutorials"
-date: 2023-03-15
+date: 2023-04-03
 tags:
 ---
 

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ fb-img:
   <h3> Important Dates </h3>
   <ul>
   <li><b>Submissions open</b>: Tuesday, February 14, 2023</li>
-  <li><b>Workshops, Tutorials, and BoF submissions due</b>: Tuesday, April 4, 2023 - <b>EXTENDED</b></li>
+  <li><b>Workshops, Tutorials, and BoF submissions due</b>: Tuesday, April 11, 2023 - <b>EXTENDED</b></li>
   <li><b>Papers / Notebooks due</b>: Monday, May 1, 2023</li>
   <li><b>Poster / Talk abstracts due</b>: Monday, June 19, 2023</li>
   <li><b>Conference Date</b>: October 16-18, 2023, Chicago, IL</li>

--- a/pages/about/dates.md
+++ b/pages/about/dates.md
@@ -11,7 +11,7 @@ set_last_modified: true
 ## Submissions
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 4, 2023 - **EXTENDED**
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023 - **EXTENDED**
 - **Notification of authors for workshops, tutorials, and BoFs**: Monday, April 24, 2023
 - **Papers / Notebooks due**: Monday, May 1, 2023
 - **Registration opens**: Monday, May 1, 2023

--- a/pages/participate/participate.md
+++ b/pages/participate/participate.md
@@ -31,7 +31,7 @@ include (but are not limited to):
 **Important Dates**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 4, 2023 - **EXTENDED**
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023 - **EXTENDED**
 - **Papers / Notebooks due**: Monday, May 1, 2023
 - **Poster / Talk abstracts due**: Monday, June 19, 2023
 
@@ -137,7 +137,7 @@ events that will run in parallel tracks.  Submissions should adhere to the
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 4, 2023 - **EXTENDED**
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023 - **EXTENDED**
 - **Notification of authors for workshops, tutorials, and BoFs**: Monday, April 24, 2023
 - **Registration for authors of workshops, tutorials, and BoFs**: Monday, June 26, 2023
 
@@ -153,7 +153,7 @@ to Friday, October 13th. Submissions should adhere to the
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 4, 2023 - **EXTENDED**
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023 - **EXTENDED**
 - **Notification of authors for workshops, tutorials, and BoFs**: Monday, April 24, 2023
 - **Registration for authors of workshops, tutorials, and BoFs**: Monday, June 26, 2023
 

--- a/pages/participate/templates.md
+++ b/pages/participate/templates.md
@@ -10,7 +10,7 @@ set_last_modified: true
 
 ## Birds of a Feather
 
-A Birds of a Feather (BoF) submission (due **April 4, 2023**) should include:
+A Birds of a Feather (BoF) submission (due **April 11, 2023**) should include:
 
 - **Title**
 - **Session Leaders**: Name, email, and affiliation of each leader
@@ -31,7 +31,7 @@ A Birds of a Feather (BoF) submission (due **April 4, 2023**) should include:
 
 ## Workshop
 
-A Workshop submission (due **April 4, 2023**) should include:
+A Workshop submission (due **April 11, 2023**) should include:
 
 - **Title**
 - **Organizers**: Name, email, and affiliation of each organizer
@@ -52,7 +52,7 @@ A Workshop submission (due **April 4, 2023**) should include:
 
 ## Tutorials
 
-A Tutorial submission (due **April 4, 2023**) should include:
+A Tutorial submission (due **April 11, 2023**) should include:
 
 - **Title**
 - **Presenters**: Name, email, and affiliation of each presenter


### PR DESCRIPTION
## Description
Extend the due date for Workshops/BoFs/Tutorials

## Motivation and Context
We want to provide more time.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

