### PR TITLE
Adding information for all committees to dropdown

### DIFF
--- a/_data/menus/organization.yml
+++ b/_data/menus/organization.yml
@@ -1,6 +1,18 @@
 - label: Organization
   items:
+    - name: Overview
+      link: organization/
+    - name: General Chairs
+      link: organization/general/
+    - name: Diversity
+      link: organization/diversity/
     - name: Outreach
       link: organization/outreach/
     - name: Technical Program
       link: organization/technical/
+    - name: Publication
+      link: organization/publication/
+    - name: Sponsorship
+      link: organization/sponsorship/
+    - name: Student
+      link: organization/student/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -20,12 +20,23 @@
     - name: Travel
       link: attend/travel/
 - name: Organization
-  link: organization/
   dropdown:
+    - name: Overview
+      link: organization/
+    - name: General Chairs
+      link: organization/general/
+    - name: Diversity
+      link: organization/diversity/
     - name: Outreach
       link: organization/outreach/
     - name: Technical Program
       link: organization/technical/
+    - name: Publication
+      link: organization/publication/
+    - name: Sponsorship
+      link: organization/sponsorship/
+    - name: Student
+      link: organization/student/
 - name: Sponsor
   link: sponsor/
 - name: About

--- a/pages/organization/diversity.md
+++ b/pages/organization/diversity.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Diversity, Equity, and Inclusion Committee
+description: 
+menubar: organization
+permalink: organization/diversity/
+set_last_modified: true
+---
+
+## Chairs
+
+- Ludovico Bianchi, Lawrence Berkeley National Laboratory
+- Tab Memmott, Oregon Health and Science University
+- Lance Parsons, Princeton University

--- a/pages/organization/general.md
+++ b/pages/organization/general.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: General Chairs
+description: 
+menubar: organization
+permalink: organization/general/
+set_last_modified: true
+---
+
+- Sandra Gesing, University of Illinois Discovery Partners Institute
+- Julia Damerow, Arizona State University

--- a/pages/organization/organization.md
+++ b/pages/organization/organization.md
@@ -28,7 +28,7 @@ set_last_modified: true
 - Charles Ferenbaugh, Los Alamos National Laboratory
 - Torin White, University of Illinois at Chicago
 
-### Sponsor Chairs
+### Sponsorship Chairs
 - Angela Herring, Los Alamos National Laboratory
 - Mahmood Shad, Harvard Research Computing, Harvard University
 - Chris Hill, MIT
@@ -36,6 +36,16 @@ set_last_modified: true
 ### Student Chairs
 - Nicole Brewer, Arizona State University
 - Carrie Brown, Pennsylvania State University
+
+## Advisory Board
+
+Additional advisory for the conference is provided by the current members of
+the [US-RSE Steering Committee](https://us-rse.org/about/steering-committee/).
+
+- Jeffrey C. Carver, University of Alabama
+- Ian Cosden, Princeton University
+- Rinku Gupta, Argonne National Laboratory
+- Christina Maimone, Northwestern University
 
 ### Contact
 

--- a/pages/organization/outreach.md
+++ b/pages/organization/outreach.md
@@ -7,12 +7,26 @@ permalink: organization/outreach/
 set_last_modified: true
 ---
 
-## Outreach Committee Chairs
+## Chairs
 
 - Caleb Jackson, Sandia National Laboratories
 - Miranda Mundt, Sandia National Laboratories
 
 ## Subcommittee Volunteers
+
+### US-RSE Outreach Working Group
+
+Additional support is provided by the members of the
+[US-RSE Outreach Working Group](https://us-rse.org/wg/outreach/).
+
+- Daniel Katz
+- Evan Harvey
+- Joshua Teves
+- Lance Parsons
+- Lezlie Espana
+- Luke Rasmussen
+- Marshall McDonnell
+- Sam Reeve
 
 ### Website
 

--- a/pages/organization/publication.md
+++ b/pages/organization/publication.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Publication Committee
+description: 
+menubar: organization
+permalink: organization/publication/
+set_last_modified: true
+---
+
+## Chairs
+
+- Charles Ferenbaugh, Los Alamos National Laboratory
+- Torin White, University of Illinois at Chicago

--- a/pages/organization/sponsorship.md
+++ b/pages/organization/sponsorship.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Sponsorship Committee
+description: 
+menubar: organization
+permalink: organization/sponsorship/
+set_last_modified: true
+---
+
+## Chairs
+
+- Angela Herring, Los Alamos National Laboratory
+- Mahmood Shad, Harvard Research Computing, Harvard University
+- Chris Hill, MIT

--- a/pages/organization/student.md
+++ b/pages/organization/student.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Student Program Committee
+description: 
+menubar: organization
+permalink: organization/student/
+set_last_modified: true
+---
+
+## Chairs
+
+- Nicole Brewer, Arizona State University
+- Carrie Brown, Pennsylvania State University

--- a/pages/organization/technical.md
+++ b/pages/organization/technical.md
@@ -7,7 +7,7 @@ permalink: organization/technical/
 set_last_modified: true
 ---
 
-# Technical Program Chairs
+## Chairs
 
 - Mariam Kiran, Lawrence Berkeley National Laboratory
 - Kenton McHenry, National Center for Supercomputing Applications, University of Illinois Urbana-Champaign


### PR DESCRIPTION
## Description
This PR changes the `Organization` dropdown to ensure better navigation.

![New Organization Dropdown Menu](https://user-images.githubusercontent.com/55767766/230110149-2bfa8cbe-e5a0-4499-abb9-bbbe896e0058.png)

![Lefthand navigation menu](https://user-images.githubusercontent.com/55767766/230110171-15b0f023-e4f7-4f9f-80a9-f48c9d0f53ec.png)

![Advisory board information](https://user-images.githubusercontent.com/55767766/230110173-39e61d2d-06be-458a-aca4-c12733260c26.png)


## Motivation and Context
To provide clarity of information.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

