### PR TITLE
Extend Papers and Notebooks Deadline

### DIFF
--- a/_posts/2023-04-24-extend-papers.md
+++ b/_posts/2023-04-24-extend-papers.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "EXTENDED: Submission Deadline for Papers and Notebooks"
+date: 2023-04-24
+tags:
+---
+
+The due date for paper (long and short) and notebook submissions
+has been extended to **Monday, May 8, 2023**.

--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@ fb-img:
   <h3> Important Dates </h3>
   <ul>
   <li><b>Submissions open</b>: Tuesday, February 14, 2023</li>
-  <li><b>Workshops, Tutorials, and BoF submissions due</b>: Tuesday, April 11, 2023 - <b>EXTENDED</b></li>
-  <li><b>Papers / Notebooks due</b>: Monday, May 1, 2023</li>
+  <li><b>Workshops, Tutorials, and BoF submissions due</b>: Tuesday, April 11, 2023</li>
+  <li><b>Papers / Notebooks due</b>: Monday, May 8, 2023 - <b>EXTENDED</b></li>
   <li><b>Poster / Talk abstracts due</b>: Monday, June 19, 2023</li>
   <li><b>Conference Date</b>: October 16-18, 2023, Chicago, IL</li>
   </ul>

--- a/pages/about/dates.md
+++ b/pages/about/dates.md
@@ -11,11 +11,11 @@ set_last_modified: true
 ## Submissions
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023 - **EXTENDED**
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023
 - **Notification of authors for workshops, tutorials, and BoFs**: Wednesday, May 3, 2023
-- **Papers / Notebooks due**: Monday, May 1, 2023
-- **Registration opens**: Monday, May 1, 2023
-- **Notification of authors for papers / notebooks**: Monday, June 5, 2023
+- **Papers / Notebooks due**: Monday, May 8, 2023 - **EXTENDED**
+- **Registration opens**: Monday, May 8, 2023 (_estimated_)
+- **Notification of authors for papers / notebooks**: Monday, June 12, 2023
 - **Poster / Talk abstracts due**: Monday, June 19, 2023
 - **Camera-ready papers / notebooks due**: Monday, June 26, 2023
 - **Registration for authors of workshops, tutorials, BoFs, and papers/notebooks**: Monday, June 26, 2023

--- a/pages/participate/participate.md
+++ b/pages/participate/participate.md
@@ -31,8 +31,8 @@ include (but are not limited to):
 **Important Dates**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023 - **EXTENDED**
-- **Papers / Notebooks due**: Monday, May 1, 2023
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023
+- **Papers / Notebooks due**: Monday, May 8, 2023 - **EXTENDED**
 - **Poster / Talk abstracts due**: Monday, June 19, 2023
 
 **Submission Website**: [EasyChair](https://easychair.org/conferences/?conf=usrsecon2023)
@@ -72,8 +72,8 @@ the scientific community.
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Papers / Notebooks due**: Monday, May 1, 2023
-- **Notification of authors for papers / notebooks**: Monday, June 5, 2023
+- **Papers / Notebooks due**: Monday, May 8, 2023 - **EXTENDED**
+- **Notification of authors for papers / notebooks**: Monday, June 12, 2023
 - **Camera-ready papers / notebooks due**: Monday, June 26, 2023
 - **Registration for authors of papers/notebooks**: Monday, June 26, 2023
 
@@ -109,8 +109,8 @@ about notebook submissions.
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Papers / Notebooks due**: Monday, May 1, 2023
-- **Notification of authors for papers / notebooks**: Monday, June 5, 2023
+- **Papers / Notebooks due**: Monday, May 8, 2023 - **EXTENDED**
+- **Notification of authors for papers / notebooks**: Monday, June 12, 2023
 - **Camera-ready papers / notebooks due**: Monday, June 26, 2023
 - **Registration for authors of papers/notebooks**: Monday, June 26, 2023
 
@@ -142,7 +142,7 @@ events that will run in parallel tracks.  Submissions should adhere to the
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023 - **EXTENDED**
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023
 - **Notification of authors for workshops, tutorials, and BoFs**: Wednesday, May 3, 2023
 - **Registration for authors of workshops, tutorials, and BoFs**: Monday, June 26, 2023
 
@@ -158,7 +158,7 @@ to Friday, October 13th. Submissions should adhere to the
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023 - **EXTENDED**
+- **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023
 - **Notification of authors for workshops, tutorials, and BoFs**: Wednesday, May 3, 2023
 - **Registration for authors of workshops, tutorials, and BoFs**: Monday, June 26, 2023
 


### PR DESCRIPTION
## Description
We are extending the papers/notebooks deadline to May 8th. This PR makes that change (including adding a blog post) and also extends the notification date.

![Main page with extension information](https://user-images.githubusercontent.com/55767766/234044293-5cb6e652-d4f4-4fd6-b7ba-7ca3c6a4952d.png)

![Participate page with extension information](https://user-images.githubusercontent.com/55767766/234044320-a27d1f55-1097-4264-bf4e-36f60139016d.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

