### PR TITLE
Technical Program Subcommittee Chairs

### DIFF
--- a/pages/organization/technical.md
+++ b/pages/organization/technical.md
@@ -12,7 +12,7 @@ set_last_modified: true
 - Mariam Kiran, Lawrence Berkeley National Laboratory
 - Kenton McHenry, National Center for Supercomputing Applications, University of Illinois Urbana-Champaign
 
-## Subcommittees
+## Subcommittee Chairs
 
 ### Notebooks
 

--- a/pages/organization/technical.md
+++ b/pages/organization/technical.md
@@ -11,3 +11,32 @@ set_last_modified: true
 
 - Mariam Kiran, Lawrence Berkeley National Laboratory
 - Kenton McHenry, National Center for Supercomputing Applications, University of Illinois Urbana-Champaign
+
+## Subcommittees
+
+### Notebooks
+
+- Ludovico Bianchi, Lawrence Berkeley National Laboratory
+- Nicole Brewer, Arizona State University
+- Torin White, University of Illinois at Chicago
+
+### Posters
+- Anne Lilje, Sandia National Laboratories
+- Craig Steffen, National Center for Supercomputing Applications, University of Illinois Urbana-Champaign
+
+
+### Tutorials
+- Lauren Milechen, Massachusetts Institute of Technology
+- Greg Watson, Oak Ridge National Laboratory
+
+### Workshops
+- Jong Lee, National Center for Supercomputing Applications, University of Illinois Urbana-Champaign
+- Kevin Potter, Sandia National Laboratories
+
+### Birds of a Feather and Talks
+- Reed Milewicz, Sandia National Laboratories
+- Joshua Teves, Sandia National Laboratories
+
+### Papers
+- Evan Harvey, Sandia National Laboratories
+- Tu-Thach Quach, Sandia National Laboratories


### PR DESCRIPTION
## Description
This PR adds the technical program subcommittee chairs and their affiliations, for transparency and recognition.

![Preview of the technical program committee page](https://user-images.githubusercontent.com/55767766/234618831-60d9d631-5c54-436d-912c-e6a19d7e4bc8.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

