### PR TITLE
Add BoF, Tutorial, and Workshop information to Program dropdown

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -18,6 +18,7 @@ jobs:
       uses: crate-ci/typos@12c64918956d94e55a2ca8c5cbca111e759f5654 # version 1.13.8
       with:
         files: ./_posts ./pages ./README.md ./index.html
+        config: ./.github/workflows/typo_config.toml
 
     - name: URLs-checker
 

--- a/.github/workflows/typo_config.toml
+++ b/.github/workflows/typo_config.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# Don't correct the name "Vas"
+Vas = "Vas"

--- a/_data/menus/program.yml
+++ b/_data/menus/program.yml
@@ -1,4 +1,8 @@
 - label: Program
-  # items:
-  #   - name: Agenda
-  #     link: program/agenda/
+  items:
+    - name: Birds of a Feather
+      link: program/bofs/
+    - name: Tutorials
+      link: program/tutorials/
+    - name: Workshops
+      link: program/workshops/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,10 +8,13 @@
     - name: Notebooks
       link: participate/notebooks/
 - name: Program
-  link: program/
-  # dropdown:
-  #   - name: Agenda
-  #     link: program/agenda/
+  dropdown:
+    - name: Birds of a Feather
+      link: program/bofs/
+    - name: Tutorials
+      link: program/tutorials/
+    - name: Workshops
+      link: program/workshops/
 - name: Attend
   link: attend/
   dropdown:

--- a/_posts/2023-03-17-notebook-submission-tutorial.md
+++ b/_posts/2023-03-17-notebook-submission-tutorial.md
@@ -12,8 +12,6 @@ session with lots of Q&A. This session will be recorded for reference.
 
 **Time:** 3:00 PM EDT, 2:00 PM CDT, 1:00 PM MDT, 12:00 PM MST, 12:00 PM PDT
 
-**Registration:** [Zoom](https://asu.zoom.us/meeting/register/tZIod-Ghpz4qGNb5O23aWxuKBadudH65Fquy)
-
 [Submission of computational notebooks](https://us-rse.org/usrse23/submissions/notebooks/) are due 
 Monday, May 1, 2023. To account for the broad variety of use cases for notebooks, we are accepting 
 submissions in three categories, which were described in detail in the [March 2023 Community Call](https://youtu.be/Z4QXKDIDu6k). 

--- a/pages/program/bofs.md
+++ b/pages/program/bofs.md
@@ -1,0 +1,93 @@
+---
+layout: page
+title: Birds of a Feather
+description: 
+menubar: program
+permalink: program/bofs/
+menubar_toc: true
+set_last_modified: true
+---
+
+## Get Involved with pyOpenSci! Building diverse community around scientific Python open source software through peer review, training and mentorship
+
+pyOpenSci is building a diverse community around the Python open source
+software that drives open science. Attend this BoF session to learn about
+submitting a Python package to pyOpenSci's open peer review process, and
+how you as a research software engineer will benefit from our supportive
+review process. You'll also learn about best practices for pure Python
+packaging that are documented in our guide that we've recently updated with
+significant input from maintainers of Python packaging tools, core scientific
+packages and the broader community.
+
+Founded in 2018, pyOpenSci's core program is open peer review of scientific
+software with the goal of improving the quality, usability, discoverability
+and long-term maintenance of scientific packages. We also focus on diversifying
+the community through both community partnerships, and support for communities
+that have not been traditionally a part of the Python open space but who have
+interest in participating. Through our partnership with JOSS (Journal of Open
+Source Software), we also offer a publication win-win to maintainers who are
+interested in both Python modern best practices, long term community support
+and also formal publication of their software.
+
+Community is core to our organization. As such understanding the needs of 
+esearch software engineers working in the scientific Python space is critical
+as we develop our organization's structure, programs and goals.
+
+In this BoF session, we will discuss and ask for feedback on four things:
+
+1. We will review our open peer review process and how you can submit a package to us for review.
+1. We will talk about our community governance and how we are actively engaging with a variety of communities with the core goal of diversifying the Python open source space.
+1. We will answer questions and get feedback on our process to ensure that we are supporting research software engineers that are working on Python tools.
+1. We will talk about the community work that we are doing to create useful Python packaging and contributor resources that support modern approaches to Python packaging
+
+This BoF will be relevant to anyone interested in US-RSEcon 2023's theme
+enabling software, because pyOpenSci is empowering a diverse community to drive
+open science forward by building Python open source tools. The format of this
+session will be a mixture of short "how to" overviews followed by discussion
+sessions that solicit feedback.
+
+------
+
+## Notebooks as a Possible Future for Scientific Publication, Better Practices for Sharing Software, and RSE Authorship
+
+Software is now a key part of just about all scientific research and as such
+the need to support this need within science has gotten a lot of attention. One
+area of particular interest by funding agencies, such as NSF who invest in
+scientific software development, is that of sustainability and reusability
+so as to maximize the gains from these investments from research funds. One
+approach to scientific software sharing and reusability is that of utilizing
+computational notebooks as the paper itself, with it as the peer reviewed
+scholarly object. Such an effort was leveraged by the NSF EarthCube program
+n the last 3 years as a means of not only making software investments within
+geoscience more discoverable and reusable, but to also motivate the community
+itself to go through the needed effort of documenting and packaging their
+software in this manner through the peer review process which carries weight
+within academic reward systems. Given its success here the AGU put in and was
+awarded a grant from the Sloan Foundation to carry this further, bring together
+publishers and other stakeholders to work out the details as to how publications
+can actually be transition such that notebook submissions might actually replace
+paper submissions where appropriate and still be indexed, discovered, and
+accessed with existing publication systems and processes.
+
+Computational notebooks are also increasingly important tools for research and
+science communication as they can be used to teach, showcase tools, communicate
+research results, and provide friendly interfaces to interact with data and
+software. To this end, US-RSE’23 Conference accepted submissions for reproducible
+notebooks (that were rendered to HTML documents), and interactive notebooks
+(that were hosted on Binder). Drafting a rubric for better practices was
+exceptionally difficult for interactive notebooks which are, by definition, not
+fully-reproducible due to widgets or other expected user-inputs. In addition,
+all software inevitably becomes unrunnable without maintenance. How then,
+should we ensure the reproducibility of our notebooks? And should this be a
+lasting or ephemeral goal? These are open questions the notebook subcommittee
+had to reckon with as they formulated better practices for peer review and we
+feel that they are worth opening up to the RSE community at large.
+
+We propose to bring together a Birds of a Feather at US-RSE’23 to introduce
+these efforts as an area of interest for RSEs as well as explore the state of
+things right now and the areas that still need to be worked out. The format of
+the BoF will be in the form of a panel followed by a menti driven discussion
+with the audience. The panel will consist of representatives from notebook and
+notebook tool (e.g. binder) providers, AGU, and members of the US-RSE’23
+notebooks subcommittee to discuss where each is going in terms of
+supporting/using notebooks.

--- a/pages/program/program.md
+++ b/pages/program/program.md
@@ -2,7 +2,6 @@
 layout: page
 title: Program
 description: 
-menubar: program
 permalink: program/
 set_last_modified: true
 ---

--- a/pages/program/tutorials.md
+++ b/pages/program/tutorials.md
@@ -1,0 +1,155 @@
+---
+layout: page
+title: Tutorials
+description: 
+menubar: program
+permalink: program/tutorials/
+menubar_toc: true
+set_last_modified: true
+---
+
+## GitHub Actions for Scientific Data Workflows
+
+_Valentina Staneva, eScience Institute, University of Washington_
+
+In this tutorial we will introduce GitHub Actions as a tool for lightweight
+automation of scientific data workflows. GitHub Actions have become a key
+tool of the software development lifecycle, however, many scientific
+programmers who are not involved in software deployment may not be familiar
+with their functionalities and/or do not know how they can be applied within
+their data pipeline. Through a sequence of examples, we will demonstrate some
+of GitHub Actions' applications to automating data processing tasks, such as
+scheduled deployment of algorithms to streaming data, updating visualizations
+based on new data, model versioning and performance benchmarking. For the
+demonstration we will access a public hydrophone stream and compute and
+visualize statistics of sound patterns. The goal is that participants will
+leave with their own ideas on how to integrate GitHub Actions in their own work.
+
+**Prerequisites**: GitHub account, basic familiarity with git, GitHub, and
+version control, programming in a scripting language such as Python/R
+
+**Audience**: scientific programmers interested in automating components of
+their workflows through existing tools for software continuous
+integration/deployment.
+
+
+------ 
+
+## Introduction to Spatial Data Processing
+
+_Nick Santos, University of California, Merced_
+
+This tutorial provides an introduction to processing spatial data.
+The goal is that participants leave the workshop with an
+understanding of and ability to use spatial data types, coordinate systems,
+and basic data processing with spatial joins and zonal statistics. These
+processing methods allow for a wide variety of data manipulation and
+aggregation. Participants will also learn to visualize data and results
+in basic maps. Though introductory, the tutorial is designed to teach a
+skill that is important for many areas of research, but which may be new to
+some RSEs.
+
+The tutorial will use Google Colab or Jupyter notebooks and be primarily
+hands-on, with short lectures only to describe core concepts with graphics.
+The workshop will use Python with the geopandas and rasterstats libraries but
+will emphasize concepts and topics that can be applied in any language or
+computing environment that supports spatial data. Participants will only need
+access to a web browser.
+
+**Prerequisites**: Required background knowledge includes:
+
+1. Being comfortable with tabular data and the concepts of table joins (e.g. with SQL, data frames, etc)
+2. The ability to read Python code. Participants will modify and run code snippets, but won’t need to write Python code without using an example as a base.
+
+**Audience**: research software engineers who are already familiar with tabular and/or image data but do not yet
+have experience with the characteristics and requirements of spatial information.
+
+------
+
+## Software Quality Practices for Reproducibility
+
+_Reed Milewicz and Miranda Mundt, Sandia National Laboratories_
+
+
+In this tutorial, participants will learn about evidence-based software
+engineering strategies for addressing reproducibility across the software
+lifecycle. The tutorial will center around three interrelated topics:
+
+1. Setting software quality priorities around reproducibility
+2. Tailored software development practices that facilitate reproducibility 
+3. Software process improvement techniques for incrementally introducing those practices into teams' workflows
+
+Participants will receive instruction on managing software quality priorities
+with regards to reproducibility, hear insights from real-world teams on
+practices that facilitate reproducibility, and finally will learn how to take
+concrete steps toward improving those practices within their respective projects
+based on the Productivity and Sustainability Improvement Planning (PSIP)
+toolkit which the presenters previously helped develop and pioneer for use with
+teams in the Exascale Computing Project.
+
+The course content represents a living curriculum based on the organizers'
+ongoing research with real-world teams into software quality practices for
+reproducibility. Organizers will solicit feedback on how to improve upon or
+add to the tutorial. The outcome of this session will be concrete steps that
+teams can take to improve their development practices with respect to
+reproducibility, and participants will learn some of the skills needed to
+approach their teams and precipitate process improvement.
+
+**Audience**: research software engineers and other professionals responsible
+for supporting, developing, and maintaining the development and use of
+scientific and engineering software systems and workflows. This includes
+students and researchers as well as the core production practitioners. 
+
+The course is relevant both for people looking to learn more about best
+practices in engineering reproducible software and for those hoping to promote
+those best practices within their respective institutions.
+
+------
+
+## Using Globus Platform Services in Research Software Applications
+
+_Lee Liming, Steve Turoscy, and Vas Vasiliadis, University of Chicago_
+
+Research applications increasingly need to leverage, and often orchestrate,
+diverse systems: campus data storage and computing systems, national data and
+computing centers, and data-generating instruments such as gene sequencers,
+Cryo-EM microscopes, CT scanners, and sensor networks. Unless these interactions
+are automated, this is time-consuming and wasteful of scarce human resources on
+research teams.
+
+The Globus platform enables research applications developed by research teams
+to leverage data and compute services across many tiers of service—from
+personal computers and local storage to national supercomputing centers—with
+minimal deployment and maintenance burden. Globus is operated by the
+University of Chicago and is used by nearly all R1 universities, national labs,
+and supercomputing centers in the United States, as well as many smaller institutions.
+
+In this tutorial, we’ll begin by introducing the Globus platform-as-a-service,
+including how to register an application and how to access Globus APIs using
+our Python SDK. We will present examples of how the various Globus services,
+interfaces, and tools may be used to develop research applications. We will walk
+participants through authentication and access control with Globus’s Auth and
+Groups APIs; making data findable and accessible using Globus guest collections,
+data transfer API, and indexed Search API; and automating research with
+Globus’s Flows and Compute APIs. Participants will use Jupyter notebooks to
+experiment with these capabilities, and they will also become familiar with
+the Globus web application.
+
+This tutorial is hands-on, utilizing Jupyter notebooks on our cloud-hosted
+JupyterHub system, accessible via web browser.
+
+The presenters lead projects—sponsored by NSF, NIH, and DOE—that are building
+research applications leveraging the Globus platform. Employed by the
+University of Chicago and Argonne National Laboratory, we have decades of
+combined experience with both building research applications and teaching
+collaborators how to build them.
+
+**Prerequisites**: Tutorial participants should have beginner to intermediate
+familiarity with Python. 
+
+**Audience**: research software engineers supporting teams whose work needs to be
+scaled up (either to solve larger problems or to achieve a faster rate of
+smaller problems) using university research computing resources, national-scale
+systems (NSF, DOE, NASA), or cloud systems.
+
+------

--- a/pages/program/workshops.md
+++ b/pages/program/workshops.md
@@ -1,0 +1,49 @@
+---
+layout: page
+title: Workshops
+description: 
+menubar: program
+permalink: program/workshops/
+set_last_modified: true
+---
+
+## Emerging as a Team Leader through Cultural Challenges
+
+In this interactive workshop we explore how meeting technical objectives depends
+critically on meeting cultural challenges within teams. Many small teams evolve
+naturally on a positive path because teams are often formed by friendly
+collaborators with common interests and goals. But as teams grow, they face
+new challenges, including fragmented time commitments, physically distributed
+developers, and growing numbers of stakeholders. These challenges make it
+significantly harder to maintain a healthy team culture. In addition, it
+becomes important to understand how to identify and responsibly use one’s
+informal influence to navigate organizations and galvanize team members.
+Although agile methodologies and modern software tools can help developers
+manage these challenges, these processes alone are insufficient. Thus, a
+growing number of teams are combining these methodologies with techniques
+that support a collaborative culture. We explore lightweight progress tracking,
+informal "tea-time", hybrid scrums, human-centered design, empathy building,
+listening games, and hands on exercises with Legos. The session is 180 min of
+guided small group exercises and debriefing, followed by 30 min of large group
+discussion and retrospective. We recap lessons learned and explore how culture
+affects team performance and emerging as a team leader. We focus on skill
+building in intercultural and interpersonal communication, and inclusion.
+
+------ 
+
+## [Software Engineering for Research Software Engineering (SE4RSE’23)](https://se4science.org/workshops/se4rse23/index.htm)
+
+This half-day (3.5 hour) workshop focuses on understanding appropriate software
+engineering practices employed by Research Software Engineers to design, develop,
+maintain, evolve, and sustain research software. As a result of the variety and
+complexity of the research domains addressed by this software, it is unclear to
+what extent existing software engineering practices and tools developed for
+industrial software are efficient and effective for its development. Appropriate
+software engineering approaches must account for the salient characteristics
+of the research-oriented development environment. This workshop provides a
+platform for RSEs to share their software engineering experiences (both
+positive and negative) and learn from each other. We will devote a significant
+portion of the workshop to focused interactions to identify common experiences,
+needs, and opportunities for future work.
+
+------ 


### PR DESCRIPTION
## Description
This PR adds the currently available program data for BoFs, Workshops, and Tutorials that have been accepted.

I say "currently available" because some data is not yet here due to revisions/etc.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

