### PR TITLE
Announce Special Issue Editors

### DIFF
--- a/_data/menus/organization.yml
+++ b/_data/menus/organization.yml
@@ -12,6 +12,8 @@
       link: organization/technical/
     - name: Publication
       link: organization/publication/
+    - name: Special Issue Editors
+      link: organization/special-issue/
     - name: Sponsorship
       link: organization/sponsorship/
     - name: Student

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -36,6 +36,8 @@
       link: organization/technical/
     - name: Publication
       link: organization/publication/
+    - name: Special Issue Editors
+      link: organization/special-issue/
     - name: Sponsorship
       link: organization/sponsorship/
     - name: Student

--- a/_posts/2023-05-23-special-issue.md
+++ b/_posts/2023-05-23-special-issue.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: "ANNOUNCEMENT: Special Issue Submission Opportunity"
+date: 2023-05-23
+tags:
+---
+
+We are happy to announce that Sandra Gesing and Patrick Diehl are acting as
+Special Issue Editors for US-RSE'23.
+
+They are looking into options to invite accepted and presented submissions to
+US-RSE'23 to submit to a special issue in a suitable journal post-conference.
+
+Authors of selected submissions will receive the invitation after the conference.

--- a/pages/organization/organization.md
+++ b/pages/organization/organization.md
@@ -28,6 +28,10 @@ set_last_modified: true
 - Charles Ferenbaugh, Los Alamos National Laboratory
 - Torin White, University of Illinois at Chicago
 
+### Special Issue Editors
+- Patrick Diehl, Louisiana State University
+- Sandra Gesing, University of Illinois Discovery Partners Institute
+
 ### Sponsorship Chairs
 - Angela Herring, Los Alamos National Laboratory
 - Mahmood Shad, Harvard Research Computing, Harvard University

--- a/pages/organization/special.md
+++ b/pages/organization/special.md
@@ -1,0 +1,13 @@
+---
+layout: page
+title: Special Issue Editors
+description: 
+menubar: organization
+permalink: organization/special-issue/
+set_last_modified: true
+---
+
+## Editors
+
+- Patrick Diehl, Louisiana State University
+- Sandra Gesing, University of Illinois Discovery Partners Institute

--- a/pages/participate/participate.md
+++ b/pages/participate/participate.md
@@ -47,6 +47,10 @@ the proceedings. Instructions for camera-ready versions will be sent to authors
 of accepted submissions. All submission types will be published as open access
 in Zenodo.
 
+The Special Issue Editors are looking into options to invite accepted and presented submissions to
+US-RSE'23 to submit to a special issue in a suitable journal post-conference.
+Authors of selected submissions will receive the invitation after the conference.
+
 **Questions?** Contact the organizers: [usrsecon2023@easychair.org](mailto:usrsecon2023@easychair.org).
 
 ------


### PR DESCRIPTION
## Description

Per @sandragesing , this PR adds the role of Special Issue Editors, creates a post announcement, and adds the information to the participate page.

![Special Issue Editor Announcement post](https://github.com/USRSE/usrse23/assets/55767766/df6824ed-ed6b-4b6e-992d-cb0d51f3d854)

![Participate page with information about special issue](https://github.com/USRSE/usrse23/assets/55767766/c8ff2eb4-24d0-4403-ad01-cc6df88ac539)

![Organization page with names of special issue editors](https://github.com/USRSE/usrse23/assets/55767766/e29f053d-5dc4-4d0e-b7fd-1308a164ce5a)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

