### PR TITLE
Extend due date for Talks and Posters to June 26

### DIFF
--- a/_posts/2023-06-16-extend-talks-posters.md
+++ b/_posts/2023-06-16-extend-talks-posters.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: "EXTENDED: Submission Deadline for Talks and Posters"
+date: 2023-06-16
+tags:
+---
+
+The due date for talk and poster submissions
+has been extended to **Monday, June 26, 2023**.

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@ fb-img:
   <ul>
   <li><b>Submissions open</b>: Tuesday, February 14, 2023</li>
   <li><b>Workshops, Tutorials, and BoF submissions due</b>: Tuesday, April 11, 2023</li>
-  <li><b>Papers / Notebooks due</b>: Monday, May 15, 2023 - <b>FINAL EXTENSION</b></li>
-  <li><b>Poster / Talk abstracts due</b>: Monday, June 19, 2023</li>
+  <li><b>Papers / Notebooks due</b>: Monday, May 15, 2023</li>
+  <li><b>Poster / Talk abstracts due</b>: Monday, June 26, 2023 - <b>EXTENDED</b></li>
   <li><b>Conference Date</b>: October 16-18, 2023, Chicago, IL</li>
   </ul>
   

--- a/pages/about/dates.md
+++ b/pages/about/dates.md
@@ -13,12 +13,12 @@ set_last_modified: true
 - **Submissions open**: Tuesday, February 14, 2023
 - **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023
 - **Notification of authors for workshops, tutorials, and BoFs**: Wednesday, May 3, 2023
-- **Papers / Notebooks due**: Monday, May 15, 2023 - **EXTENDED**
+- **Papers / Notebooks due**: Monday, May 15, 2023
 - **Registration opens**: Monday, May 15, 2023 (_estimated_)
 - **Notification of authors for papers / notebooks**: Monday, June 26, 2023
-- **Poster / Talk abstracts due**: Monday, June 19, 2023
+- **Poster / Talk abstracts due**: Monday, June 26, 2023 - **EXTENDED**
 - **Registration for authors of workshops, tutorials, BoFs, and papers/notebooks**: mid-July 2023
-- **Camera-ready papers / notebooks due**: Monday, July 3, 2023
+- **Camera-ready papers / notebooks due**: Monday, July 10, 2023
 - **Notification of authors for posters / talks**: Monday, July 24, 2023
 - **Registration for authors of posters / talks**: Monday, August 21, 2023
 - **Early-bird registration ends**: Monday, August 21, 2023

--- a/pages/participate/participate.md
+++ b/pages/participate/participate.md
@@ -32,8 +32,8 @@ include (but are not limited to):
 
 - **Submissions open**: Tuesday, February 14, 2023
 - **Workshops, Tutorials, and BoF submissions due**: Tuesday, April 11, 2023
-- **Papers / Notebooks due**: Monday, May 15, 2023 - **EXTENDED**
-- **Poster / Talk abstracts due**: Monday, June 19, 2023
+- **Papers / Notebooks due**: Monday, May 15, 2023
+- **Poster / Talk abstracts due**: Monday, June 26, 2023
 
 **Submission Website**: [EasyChair](https://easychair.org/conferences/?conf=usrsecon2023)
 
@@ -76,7 +76,7 @@ the scientific community.
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Papers / Notebooks due**: Monday, May 15, 2023 - **EXTENDED**
+- **Papers / Notebooks due**: Monday, May 15, 2023
 - **Notification of authors for papers / notebooks**: Monday, June 26, 2023
 - **Registration for authors of papers/notebooks**: mid-July 2023
 - **Camera-ready papers / notebooks due**: Monday, July 10, 2023
@@ -92,7 +92,7 @@ Talk submissions should be in the form of an abstract, no more than 1 page in le
 **Timeline**
 
 - **Submissions open**: Thursday, February 16, 2023
-- **Talk abstracts due**: Monday, June 19, 2023
+- **Talk abstracts due**: Monday, June 26, 2023 - **EXTENDED**
 - **Notification of authors for talks**: Monday, July 24, 2023
 - **Registration for authors of talks**: Monday, August 21, 2023
 
@@ -113,7 +113,7 @@ about notebook submissions.
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Papers / Notebooks due**: Monday, May 15, 2023 - **EXTENDED**
+- **Papers / Notebooks due**: Monday, May 15, 2023
 - **Notification of authors for papers / notebooks**: Monday, June 26, 2023
 - **Registration for authors of papers/notebooks**: mid-July 2023
 - **Camera-ready papers / notebooks due**: Monday, July 3, 2023
@@ -129,7 +129,7 @@ of an abstract, no more than 1 page in length.
 **Timeline**
 
 - **Submissions open**: Tuesday, February 14, 2023
-- **Poster abstracts due**: Monday, June 19, 2023
+- **Poster abstracts due**: Monday, June 26, 2023 - **EXTENDED**
 - **Notification of authors for posters**: Monday, July 24, 2023
 - **Registration for authors of posters**: Monday, August 21, 2023
 - **Camera-ready posters due**: Monday, August 28, 2023


### PR DESCRIPTION
## Description

We are extending the due date for Talks/Posters by one week.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

