### PR TITLE
Set camera-ready due date to notebooks to July 10

### DIFF
--- a/pages/participate/participate.md
+++ b/pages/participate/participate.md
@@ -116,7 +116,7 @@ about notebook submissions.
 - **Papers / Notebooks due**: Monday, May 15, 2023
 - **Notification of authors for papers / notebooks**: Monday, June 26, 2023
 - **Registration for authors of papers/notebooks**: mid-July 2023
-- **Camera-ready papers / notebooks due**: Monday, July 3, 2023
+- **Camera-ready papers / notebooks due**: Monday, July 10, 2023
 
 ------
 


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the Committee chairs are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for the Committee chairs
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Change the camera-ready due date to notebooks to July 10

## Motivation and Context

- We noticed that the camera-ready due date for notebooks was listed as July 10 on one page, and July 3 on another

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] (Committee Chairs Only) I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @mrmundt @cabejackson @manning-ncsa @jmelot @jbteves @jsubida

